### PR TITLE
Reference extension documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This page has some information on where to get information and get plugged into 
 
 {% page-ref page="the-basics/getting-started.md" %}
 
+### Extension Development
+
+The [Extension API](https://thunderbird-webextensions.readthedocs.io/) documentation covers available APIs and guides to move to the new set of APIs.
+
 ## Report Bugs and Request Features
 
 ### [Bugzilla](https://bugzilla.mozilla.org)


### PR DESCRIPTION
I'm not sure if this is entirely the correct place or a great text to embed the extension docs link, but I think linking out to the extension docs should definitely happen - unless they get moved to this, too.