### PR TITLE
Update about-add-ons.md

### DIFF
--- a/add-ons/about-add-ons.md
+++ b/add-ons/about-add-ons.md
@@ -42,9 +42,9 @@ Since Thunderbird 60 was released, there have been many major changes to Thunder
 
 If you are currently maintaining a legacy extension please consider checking out our guide on updating extensions for Thunderbird 68:
 
-## Themes
-
 {% page-ref page="upgrading-add-ons-for-tb68/" %}
+
+## Themes
 
 Themes change the way that Thunderbird looks, for instance - here is a screenshot of the side panel using the built-in dark theme:
 


### PR DESCRIPTION
The main AddOn-Page is broken and cannot be edited via the frontend anymore. You cannot move links around anymore. I think this is related to the external link, which is not present in the github code, but in the gitbook. Very strange. This PR moves the link of the Update Guide to the correct position.