### PR TITLE
Add renaming of mail-multi-emailHeaderField

### DIFF
--- a/add-ons/tb68/changes.md
+++ b/add-ons/tb68/changes.md
@@ -353,6 +353,17 @@ The following JavaScript files also need to be included:
 
 If you do not want to be dependent on Lightning being installed, you need to include the above files with your add-on.
 
+## Renamed XUL elements
+
+### &lt;mail-multi-emailHeaderField&gt;
+
+The element `mail-multi-emailHeaderField` has been renamed into `mail-multi-emailheaderfield` (no camelCase anymore).
+
+See e.g. https://searchfox.org/comm-central/source/mail/base/content/msgHdrView.inc.xul#238
+```
+<mail-multi-emailheaderfield id="expandedfromBox" flex="1"/>
+```
+
 ## Changed event behavior
 
 ### &lt;dialog&gt; events


### PR DESCRIPTION
Add info about renaming of mail-multi-emailheaderfield (no more camelCase) used e.g. in addon CompactHeader