### PR TITLE
Generic string method deprecation

### DIFF
--- a/add-ons/updates/tb68.md
+++ b/add-ons/updates/tb68.md
@@ -431,7 +431,7 @@ represent changes that affect Javascript extension developers.
 ### String Generic Methods Deprecated
 
 The nonstandard generic string methods have been deprecated and removed in the Geko engine
-and therefore Thunderbird 68.  A nonfatal deprecation warning is issued if any methods are used.
+and therefore Thunderbird 68+.  A deprecation exception is issued if any methods are used.
 The updated paradigm uses String instance methods allowing for the use on any object.
 
 Deprecated Generics Syntax:
@@ -457,6 +457,7 @@ The following String methods are affected by the change:
   toLocaleUpperCase(), localeCompare(), match(), search(), slice(),
   replace(), split(), substr(), concat(), localeCompare()
 ```
+(All other String methods use the instance paradigm already)
 
 ## Changes for JavaScript modules
 

--- a/add-ons/updates/tb68.md
+++ b/add-ons/updates/tb68.md
@@ -423,6 +423,41 @@ This is valid for `ondialogaccept`, `ondialogextra1`, `ondialogextra2` and `ondi
 
 The section about `<dialog>` events also applies to all `onwizard…` events on `<wizard>`, and `onpage…` events on `<wizardpage>`.
 
+## Changes to Geko JavaScript Engine
+
+As JavaScript itself evolves, browser engines will change accordingly.  The following changes
+represent changes that affect Javascript extension developers.
+
+### String Generic Methods Deprecated
+
+The nonstandard generic string methods have been deprecated and removed in the Geko engine
+and therefore Thunderbird 68.  A nonfatal deprecation warning is issued if any methods are used.
+The updated paradigm uses String instance methods allowing for the use on any object.
+
+Deprecated Generics Syntax:
+
+```JavaScript
+var strWithPadding = "   Hello There   "; 
+String.trim(strWithPadding);
+```
+
+Instance Method Replacement:
+
+```JavaScript
+var strWithPadding = "   Hello There   "; 
+strWithPadding.trim();
+```
+
+The following String methods are affected by the change:
+
+```JavaScript
+  contains(), substring(), toLowerCase(), toUpperCase(), charAt(),
+  charCodeAt(), indexOf(), lastIndexOf(), startsWith(), endsWith(),
+  trim(), trimLeft(), trimRight(), toLocaleLowerCase(), normalize(),
+  toLocaleUpperCase(), localeCompare(), match(), search(), slice(),
+  replace(), split(), substr(), concat(), localeCompare()
+```
+
 ## Changes for JavaScript modules
 
 ### Renamed JavaScript modules


### PR DESCRIPTION
Firefox removed String generics In 68