### PR TITLE
Updated documentation for rust and cargo on Linux

### DIFF
--- a/the-basics/building-thunderbird/linux-build-prerequisites.md
+++ b/the-basics/building-thunderbird/linux-build-prerequisites.md
@@ -70,6 +70,11 @@ export PATH=$HOME/.cargo/bin:$PATH
 ```
 {% endhint %}
 
+{% hint style="warning" %}
+If you still are unable to find rustc and cargo via the which command after installing them, you may need to restart your session (log out and back into your user account, or restart your computer) to be able to see them.
+
+{% endhint %}
+
 ## You're all set
 
 Got back to the [Building Thunderbird](./#build-configuration) page and continue following the guide.

--- a/the-basics/building-thunderbird/linux-build-prerequisites.md
+++ b/the-basics/building-thunderbird/linux-build-prerequisites.md
@@ -71,7 +71,7 @@ export PATH=$HOME/.cargo/bin:$PATH
 {% endhint %}
 
 {% hint style="warning" %}
-If you still are unable to find rustc and cargo via the which command after installing them, you may need to restart your session (log out and back into your user account, or restart your computer) to be able to see them.
+If you still are unable to find rustc and cargo via the ˋwhichˋ command after installing them, you may need to restart your session (log out and back into your user account, or restart your computer) to be able to see them.
 
 {% endhint %}
 


### PR DESCRIPTION
An update to provide more info to users who are unable to see rust and cargo after installing.