### PR TITLE
hello world panelUI filename changed from .xul to .xhtml

### DIFF
--- a/examples/hello-world.md
+++ b/examples/hello-world.md
@@ -49,10 +49,10 @@ function helloWorld(){
 For this tutorial we are going to create a new menu item in the App Menu \(often called the hamburger menu\) to call our `helloWorld()` function in `mailCore.js`.
 
 {% hint style="info" %}
-For this part of the tutorial we are going to interact with a XUL file. **XUL** \(XML User Interface Language\) is Mozilla's XML-based language for building user interfaces of applications.
+For this part of the tutorial we are going to interact with a XHTML file.
 {% endhint %}
 
-In the directory: `comm -> mail -> components -> customizableui -> content` - we are going to open the file `panelUI.inc.xul` and find the `"appmenu_help"` toolbarbutton \(you'll likely want to use **Ctrl+F** again to find it\).
+In the directory: `comm -> mail -> components -> customizableui -> content` - we are going to open the file `panelUI.inc.xhtml` and find the `"appmenu_help"` toolbarbutton \(you'll likely want to use **Ctrl+F** again to find it\).
 
 Once you found the `appmenu_help` toolbarbutton, insert the following code below it:
 
@@ -66,7 +66,7 @@ Once you found the `appmenu_help` toolbarbutton, insert the following code below
 In context:
 
 {% tabs %}
-{% tab title="panelUI.inc.xul" %}
+{% tab title="panelUI.inc.xhtml" %}
 ```markup
 <toolbarbutton id="appmenu_help"
                class="subviewbutton subviewbutton-iconic subviewbutton-nav"


### PR DESCRIPTION
The hello world docs still said 'panelUI.inc.xul'. I changed it to xhtml. I guess i could do this minor change as a first exercise.
I had to remove the info about xul: 
"**XUL** \(XML User Interface Language\) is Mozilla's XML-based language for building user interfaces of applications."
I don't know how important this info is for new developers? I feel like everything will change to xhtml? If not, i guess this info should be placed somewhere else.
