### PR TITLE
Typofix of "Tor"

### DIFF
--- a/planning/roadmap.md
+++ b/planning/roadmap.md
@@ -262,7 +262,7 @@ Set up performance measuring. Investigate performance bottlenecks and improve UI
 * cert deployment?
 * XMPP/Jingle support. [Bug 1018060](https://bugzilla.mozilla.org/show_bug.cgi?id=1018060) \[If we can get sponsorship?\]
 
-### TOR uplift for Thunderbird \[TB???\]
+### Tor uplift for Thunderbird \[TB???\]
 
 Consider an option to connect through Tor. Some mail providers support connecting through their onion services.  
 


### PR DESCRIPTION
["Tor is not spelled "TOR". Only the first letter is capitalized."](https://2019.www.torproject.org/docs/faq#WhyCalledTor)