### PR TITLE
Add warning about registerFactory on Startup

### DIFF
--- a/add-ons/updating/tb78/README.md
+++ b/add-ons/updating/tb78/README.md
@@ -212,6 +212,9 @@ getAPI(context) {
     /* ... implementation ... */ 
   };
   let factory = XPCOMUtils.generateNSGetFactory([exampleComponent])(classId);
+  // WARNING: this assumes that Thunderbird is already running, as
+  // Components.manager.registerFactory will be unavailable for a few
+  // milliseconds after startup.
   Components.manager.registerFactory(classID, "exampleComponent", contractID, 
     factory);
   context.callOnClose({close(){


### PR DESCRIPTION
Components.manager.registerFactory is lazy-loaded, so XPCOM registration
experiments may need to stall a bit before they can register classes.

This PC adds a warning regarding that.