### PR TITLE
Distribution agreement

### DIFF
--- a/add-ons/add-on-policies/thunderbird-add-on-distribution-agreement.md
+++ b/add-ons/add-on-policies/thunderbird-add-on-distribution-agreement.md
@@ -29,7 +29,7 @@ In order to distribute an Add-on, You'll need to create an account. During regis
 
 ## 3. Privacy policy
 
-Our[ **{todo: rebrand to TB: Websites, Communications and Cookies Privacy Notice**](https://www.mozilla.org/privacy/websites/)**}** describes what information we receive from developers and how we use that information. We use the information we receive as described in the[ Mozilla Privacy Policy](https://www.mozilla.org/privacy/).
+Mozilla’s [Websites, Communications and Cookies Privacy Notice](https://www.mozilla.org/privacy/websites/) describes what information we receive from developers and how we use that information. We use the information we receive as described in Mozilla’s [Privacy Policy](https://www.mozilla.org/privacy/).
 
 ## 4. Distribution & review process
 
@@ -78,7 +78,7 @@ In addition, we may at any time suspend or terminate this Agreement with You if 
 
 #### \(c\) Take Down Request.
 
-For information on how to notify Mozilla / MZLA in connection with claimed copyright or trademark infringement \(“Take-Down Request”\) see[ **{todo: rebrand or use Mozilla? here**](https://www.mozilla.org/about/legal/report-abuse/)**}**.
+For information on how to notify Mozilla / MZLA in connection with claimed copyright or trademark infringement \(“Take-Down Request”\) see [here](https://www.mozilla.org/about/legal/report-abuse/) [todo: rebrand?].
 
 ## 8. Disclaimer of warranties
 
@@ -104,7 +104,7 @@ You and MZLA agree to submit to the exclusive jurisdiction of the courts located
 
 #### \(b\) Severability; No Waiver. 
 
-If any court of law, having the jurisdiction to decide on this matter, rules that any provision of this Agreement are invalid, then that provision will be removed from this Agreement without affecting the rest of the Agreement. The remaining provisions of this Agreement will continue to be valid and enforceable. You agree that if MZLA does not exercise or enforce any legal right or remedy which is contained in this Agreement \(or which MZLA has the benefit of under any applicable law\), this will not be taken to be a formal waiver of MZLA's rights and that those rights or remedies will still be available to MZLA.
+If any court of law, having the jurisdiction to decide on this matter, rules that any provision of this Agreement are invalid, then that provision will be removed from this Agreement without affecting the rest of the Agreement. The remaining provisions of this Agreement will continue to be valid and enforceable. You agree that if MZLA does not exercise or enforce any legal right or remedy which is contained in this Agreement \(or which MZLA has the benefit of under any applicable law\), this will not be taken to be a formal waiver of MZLA’s rights and that those rights or remedies will still be available to MZLA.
 
 Entire Agreement. This Agreement constitutes the whole legal agreement between You and MZLA for distribution of Add-ons, and completely supersedes any other related agreements between You and MZLA unless You have a separately negotiated and signed agreement in connection with a specific Add-on \("Custom Agreement"\), in which case the Custom Agreement controls. Hyperlinked documents in this Agreement, including for example, [Review Policies](review-policy-for-thunderbird-add-ons.md), are incorporated herein by reference.
 
@@ -122,5 +122,5 @@ MZLA may periodically update this Agreement. The updated Agreement will be avail
 
 #### \(f\) Contact Us
 
-If You have questions about this Agreement, send an email to {**todo**: **check and update for MZLA**: legal-notices@mozilla.com or mail us at: Attn: Mozilla – Legal Notices, 331 E. Evelyn Ave., Mountain View, CA 94041.}
+If You have questions about this Agreement, send an email to: legal-notices@mozilla.com or mail us at: Attn: Mozilla – Legal Notices, 331 E. Evelyn Ave., Mountain View, CA 94041. [todo: update]
 

--- a/add-ons/add-on-policies/thunderbird-add-on-distribution-agreement.md
+++ b/add-ons/add-on-policies/thunderbird-add-on-distribution-agreement.md
@@ -2,116 +2,125 @@
 description: 'Effective Month XX, 2021 - Draft'
 ---
 
-# Firefox Add-on Distribution Agreement
+# Thunderbird Add-on Distribution Agreement
 
 ## 1. Introduction
 
-Mozilla is committed to promoting choice and innovation on the web. From the launch of Firefox, we’ve allowed anyone to create and distribute Firefox Add-ons.
+MZLA is committed to promoting choice and innovation on the web. From the launch of Thunderbird, we’ve allowed anyone to create and distribute Thunderbird Add-ons.
 
-This Firefox Add-on Distribution Agreement ("Agreement") governs Your distribution of Firefox Add-ons. Frequently used terms in this Agreement are defined below.
+This Thunderbird Add-on Distribution Agreement \("Agreement"\) governs Your distribution of Thunderbird Add-ons. Frequently used terms in this Agreement are defined below.
 
-* “Add-on” means software that extends the functionality of Firefox, for example, extensions, Background Themes (defined below), search providers, dictionaries, and language packs. Add-ons are also commonly referred to as extensions or plugins.
-* “Add-on Manager” is the Firefox tool to manage Add-ons. It can be accessed from the Firefox menu button in the toolbar.
-* “AMO” means addons.mozilla.org, which is our online platform for developers to list and distribute Add-ons to End-Users.
-* “Background Theme” means software that personalizes the look of Firefox by adding a background design to the main toolbar. Themes are a type of Add-on.
-* “Brand Features” mean the trade names, trademarks, service marks, logos, domain names, and other distinctive brand features of You or Mozilla.
+* “Add-on” means software that extends the functionality of Thunderbird, for example, extensions, Background Themes \(defined below\), search providers, dictionaries, and language packs. Add-ons are also commonly referred to as extensions or plugins.
+* “Add-on Manager” is the Thunderbird tool to manage Add-ons. It can be accessed from the Thunderbird menu button in the toolbar.
+* “ATN” means addons.thunderbird.net, which is our online platform for developers to list and distribute Add-ons to End-Users.
+* “Background Theme” means software that personalizes the look of Thunderbird by adding a background design to the main toolbar. Themes are a type of Add-on.
+* “Brand Features” mean the trade names, trademarks, service marks, logos, domain names, and other distinctive brand features of You, Mozilla or MZLA.
 * “End-Users” mean individuals who install Add-Ons, or to whom Add-ons are promoted.
-* “Firefox” means the awesome web browser developed by Mozilla.
-* “Listed Add-on” means Add-ons that are listed and distributed on AMO.
-* “Mozilla” means Mozilla Corporation, its affiliated entities, and designated community members who are part of the Add-on review process.
-* “Mozilla Certificate” means a Mozilla issued certificate to digitally sign an Add-on for use with Firefox.
-* “Signed Add-on” means an Add-on that has been issued a Mozilla Certificate.
-* “Unlisted Add-on” means Add-ons that are distributed to End-Users via means other than AMO.
-* “You” means the person or entity entering this Agreement for the purpose of distributing a Firefox Add-on.
-
+* “Thunderbird” means the awesome email client developed by the Thunderbird community.
+* “Listed Add-on” means Add-ons that are listed and distributed on ATN.
+* “Mozilla” means Mozilla Corporation and its affiliated entities.
+* “MZLA” means {... } and designated community members who are part of the Add-on review process.
+* “Unlisted Add-on” means Add-ons that are distributed to End-Users via means other than ATN.
+* “You” means the person or entity entering this Agreement for the purpose of distributing a Thunderbird Add-on.
 
 ## 2. Accounts
 
-In order to distribute an Add-on, You'll need to create an account. During registration, You will be asked to set a password. You are responsible for keeping Your password confidential and for the activity that happens through Your account. Mozilla is not responsible for any losses arising out of unauthorized use of Your account.
+In order to distribute an Add-on, You'll need to create an account. During registration, You will be asked to set a password. You are responsible for keeping Your password confidential and for the activity that happens through Your account. MZLA is not responsible for any losses arising out of unauthorized use of Your account.
 
 ## 3. Privacy policy
 
-Our Websites, Communications and Cookies Privacy Notice describes what information we receive from Developers and how we use that information. We use the information we receive as described in our Mozilla Privacy Policy.
+Our[ **{todo: rebrand to TB: Websites, Communications and Cookies Privacy Notice**](https://www.mozilla.org/privacy/websites/)**}** describes what information we receive from developers and how we use that information. We use the information we receive as described in the[ Mozilla Privacy Policy](https://www.mozilla.org/privacy/).
 
-## 4. Distribution, certificates, & review process
+## 4. Distribution & review process
 
-(a) Distribution Options
+#### **\(a\) Distribution Options**
 
-    Listed Add-ons: You can request Your Add-on to be listed and distributed on AMO. AMO is a popular site with over four billion Add-on downloads. End-Users can search titles, navigate categories, or view promoted, featured, popular, or top rated Add-ons. End-Users can also rate Add-ons and leave comments.
-    Unlisted Add-ons: Add-ons that are distributed by a method outside of AMO are common when an Add-on isn’t intended for the public or is bundled with another Add-on. For example, some Add-ons are created by a company for employees; created for research purposes by a limited group; or are in development or testing phase and not yet suitable for a general audience.
+* Listed Add-ons: You can request Your Add-on to be listed and distributed on ATN. ATN is a popular site with over four billion Add-on downloads. End-Users can search titles, navigate categories, or view promoted, featured, popular, or top rated Add-ons. End-Users can also rate Add-ons and leave comments.
+* Unlisted Add-ons: Add-ons that are distributed by a method outside of ATN are common when an Add-on isn’t intended for the public or is bundled with another Add-on. For example, some Add-ons are created by a company for employees; created for research purposes by a limited group; or are in development or testing phase and not yet suitable for a general audience.
 
-(b) Mozilla Certificates
+#### **\(b\) Review Process**
 
-With some exceptions, all Add-ons must be signed using a Mozilla Certificate, which is a digital signature that enables the Add-on to be used with Firefox. Mozilla Certificates are incorporated by Mozilla into Your Add-on (this process is also referred to as “signing an Add-on”). Exceptions include, for example, Background Themes, dictionaries, and language packs.
-
-Signed Listed Add-ons are automatically distributed by Mozilla on AMO. Links to Signed Unlisted Add-ons will be provided to You for distribution.
-(c) Review Process
-
-Listed and Unlisted Add-ons must meet certain review criteria, which are described in our Review Policies. Mozilla may at any time monitor, test or review Listed and Unlisted Add-ons for compliance with this Agreement and the Review Policies. The inclusion of an Add-on on AMO or issuance of a Mozilla Certificate is at Mozilla’s sole discretion.
+Listed and Unlisted Add-ons ****must meet certain review criteria, which are described in our [Review Policies](review-policy-for-thunderbird-add-ons.md)**.** MZLA may at any time monitor, test or review Listed and Unlisted Add-ons for compliance with this Agreement and the [Review Policies](review-policy-for-thunderbird-add-ons.md). The inclusion of an Add-on on ATN is at MZLA’s sole discretion.
 
 ## 5. Your obligations
 
 You represent and warrant that:
 
-(a) Relationship with Mozilla. You will provide accurate information and updates to Mozilla during registration and any communications with Mozilla in connection with Your Add-ons. The descriptions and other data You provide about the Add-on are true to the best of Your knowledge. Unless You and Mozilla have a written agreement stating otherwise, Your Add-on will not imply in any way that it is produced, sponsored or endorsed by Mozilla.
+\(a\) Relationship with MZLA. You will provide accurate information and updates to MZLA during registration and any communications with MZLA in connection with Your Add-ons. The descriptions and other data You provide about the Add-on are true to the best of Your knowledge. Unless You and MZLA have a written agreement stating otherwise, Your Add-on will not imply in any way that it is produced, sponsored or endorsed by MZLA.
 
-(b) Relationship with End-Users. As between You and Mozilla, You are solely responsible for Your Add-ons and the relationship between You and Your End-Users. You will provide accurate information and updates to Your End-Users about Your Add-ons, including disclosure of all security permissions and End-User data necessary for the Add-on to function. You are solely responsible for providing reasonable technical support to End-Users and You will make appropriate support contact information available.
+\(b\) Relationship with End-Users. As between You and MZLA, You are solely responsible for Your Add-ons and the relationship between You and Your End-Users. You will provide accurate information and updates to Your End-Users about Your Add-ons, including disclosure of all security permissions and End-User data necessary for the Add-on to function. You are solely responsible for providing reasonable technical support to End-Users and You will make appropriate support contact information available.
 
-(c) Intellectual Property Rights. You have and will maintain all necessary copyright, trademark, patent or other proprietary or legal rights to post, display, perform, use, reproduce, distribute and transmit Your Add-on, worldwide, as well as the rights to authorize others (including Mozilla) to do the same.
+\(c\) Intellectual Property Rights. You have and will maintain all necessary copyright, trademark, patent or other proprietary or legal rights to post, display, perform, use, reproduce, distribute and transmit Your Add-on, worldwide, as well as the rights to authorize others \(including MZLA\) to do the same.
 
-(d) Export Restrictions. Your distribution of Add-ons may be subject to United States export laws and regulations. You will comply with all domestic and international export laws and regulations that apply to Your distribution of Add-ons. These laws include restrictions on destinations, users and end use.
+\(d\) Export Restrictions. Your distribution of Add-ons may be subject to United States export laws and regulations. You will comply with all domestic and international export laws and regulations that apply to Your distribution of Add-ons. These laws include restrictions on destinations, users and end use.
 
 ## 6. Licenses; proprietary rights
 
-Mozilla encourages You to make Your Add-ons available under open source licenses such as the MPL for source code and a Creative Commons license for creative works.
+MZLA encourages You to make Your Add-ons available under open source licenses such as the MPL for source code and a Creative Commons license for creative works.
 
-You hereby grant to Mozilla a non-exclusive, worldwide, royalty-free, sublicensable license under all of Your rights necessary to review Your Add-ons (including the source code, if required); create Signed Add-ons; and publish, distribute, and promote Listed Add-ons as part of AMO or related Mozilla promotional efforts.
+You hereby grant to MZLA a non-exclusive, worldwide, royalty-free, sublicensable license under all of Your rights necessary to review Your Add-ons \(including the source code, if required\); and publish, distribute, and promote Listed Add-ons as part of ATN or related MZLA promotional efforts.
 
-Between Mozilla and You, each party shall own all right, title and interest, including without limitation all intellectual property rights, relating to its Brand Features. Mozilla does not grant You any intellectual property rights not specifically stated in this Agreement. For example, this Agreement does not provide You the right to use any of Mozilla’s Brand Features. Firefox and AMO are distributed under and subject to the current version of the Mozilla Public License, or other similarly permissive licenses.
+Between MZLA and You, each party shall own all right, title and interest, including without limitation all intellectual property rights, relating to its Brand Features. MZLA does not grant You any intellectual property rights not specifically stated in this Agreement. For example, this Agreement does not provide You the right to use any of Mozilla’s or MZLA’s Brand Features. Thunderbird and ATN are distributed under and subject to the current version of the Mozilla Public License, or other similarly permissive licenses.
 
 ## 7. Content removal
 
-(a) Removal from Distribution by You.
-You may cease distribution of Your Add-ons at any time by removing your Add-on from AMO. You agree that ceasing maintenance or distribution of Add-ons does not necessarily remove Your Add-on from End-User machines, hardware, or other devices, or from any part of AMO where previously downloaded applications are stored on behalf of End-Users (if any).
+#### \(a\) Removal from Distribution by You.
 
-(b) Removal from Distribution by Mozilla.
-Mozilla reserves the right (though not the obligation) to, in our sole discretion, remove or revoke access to any Listed or Unlisted Add-ons. This applies, but is not limited to, Add-ons that, in our reasonable opinion, violate this Agreement or the law, any applicable Mozilla policy, or is in any way harmful or objectionable. In addition, we may at any time remove Your Add-on from AMO; revoke Your Mozilla Certificate; blocklist an Add-on; delete your AMO account; flag, filter, modify related materials (including but not limited to descriptions, screenshots, or metadata); reclassify the Add-on; or take other corrective action.
+You may cease distribution of Your Add-ons at any time by removing your Add-on from ATN. You agree that ceasing maintenance or distribution of Add-ons does not necessarily remove Your Add-on from End-User machines, hardware, or other devices, or from any part of ATN where previously downloaded applications are stored on behalf of End-Users \(if any\).
 
-For example, a Listed Add-on may be removed in response to abuse reports from End-Users, in response to a Take-Down Request, or if it comes to Mozilla’s attention that the Add-on violates our Conditions of Use. An Unlisted Add-on may be blocklisted or the Mozilla Certificate revoked if it comes to Mozilla’s attention that it violates the Security Criteria described in our Review Policies.
+#### \(b\) Removal from Distribution by MZLA.
 
-In addition, we may at any time suspend or terminate this Agreement with You if we are no longer going to support the products and services related to Firefox Add-ons or issue Mozilla Certificates.
+MZLA reserves the right \(though not the obligation\) to, in our sole discretion, remove or revoke access to any Listed or Unlisted Add-ons. This applies, but is not limited to, Add-ons that, in our reasonable opinion, violate this Agreement or the law, any applicable Mozilla or MZLA policy, or is in any way harmful or objectionable. In addition, we may at any time remove Your Add-on from ATN; blocklist an Add-on; delete your ATN account; flag, filter, modify related materials \(including but not limited to descriptions, screenshots, or metadata\); reclassify the Add-on; or take other corrective action.
 
-(c) Take Down Request.
+For example, a Listed Add-on may be removed in response to abuse reports from End-Users, in response to a Take-Down Request, or if it comes to MZLA’s attention that the Add-on violates our Conditions of Use. An Unlisted Add-on may be blocklisted if it comes to MZLA’s attention that it violates the Security Criteria described in our [Review Policies](review-policy-for-thunderbird-add-ons.md).
 
-For information on how to notify Mozilla in connection with claimed copyright or trademark infringement (“Take-Down Request”) see here.
+In addition, we may at any time suspend or terminate this Agreement with You if we are no longer going to support the products and services related to Thunderbird Add-ons.
+
+#### \(c\) Take Down Request.
+
+For information on how to notify Mozilla / MZLA in connection with claimed copyright or trademark infringement \(“Take-Down Request”\) see[ **{todo: rebrand or use Mozilla? here**](https://www.mozilla.org/about/legal/report-abuse/)**}**.
 
 ## 8. Disclaimer of warranties
 
-AMO, MOZILLA CERTIFICATES, AND MOZILLA PRODUCTS AND SERVICES ARE PROVIDED “AS IS”. MOZILLA, ITS CONTRIBUTORS & LICENSORS, DISCLAIM ALL WARRANTIES, WHETHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF IMPLIED WARRANTIES, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
+ATN, MZLA PRODUCTS AND SERVICES ARE PROVIDED “AS IS”. MZLA, ITS CONTRIBUTORS & LICENSORS, DISCLAIM ALL WARRANTIES, WHETHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF IMPLIED WARRANTIES, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
 
 ## 9. Limitation of liability
 
-YOU EXPRESSLY UNDERSTAND AND AGREE THAT, EXCEPT AS REQUIRED BY LAW, MOZILLA, ITS CONTRIBUTORS & LICENSORS, WILL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT MOZILLA OR ITS AGENTS HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING. IN NO EVENT SHALL MOZILLA’S AGGREGATE LIABILITY TO YOU FOR ANY DAMAGES ARISING FROM OR RELATED TO THESE TERMS BE IN EXCESS OF THE GREATER OF (i) $100 OR (ii) THE TOTAL AMOUNTS PAID TO YOU BY MOZILLA IN THE TWELVE MONTHS IMMEDIATELY PRECEDING THE INITIAL NOTICE OF ANY CLAIM. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF CERTAIN TYPES OF LIABILITY, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
+YOU EXPRESSLY UNDERSTAND AND AGREE THAT, EXCEPT AS REQUIRED BY LAW, MZLA, ITS CONTRIBUTORS & LICENSORS, WILL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT MZLA OR ITS AGENTS HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING. IN NO EVENT SHALL MZLA’S AGGREGATE LIABILITY TO YOU FOR ANY DAMAGES ARISING FROM OR RELATED TO THESE TERMS BE IN EXCESS OF THE GREATER OF \(i\) $100 OR \(ii\) THE TOTAL AMOUNTS PAID TO YOU BY MZLA IN THE TWELVE MONTHS IMMEDIATELY PRECEDING THE INITIAL NOTICE OF ANY CLAIM. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF CERTAIN TYPES OF LIABILITY, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
 
 ## 10. Release; indemnification
 
-You release Mozilla, its officers, employees, agents and successors from claims, demands and damages of every kind or nature arising out of or related to any disputes with End-Users, including other Add-on developers.
+You release MZLA, its officers, employees, agents and successors from claims, demands and damages of every kind or nature arising out of or related to any disputes with End-Users, including other Add-on developers.
 
-If any third party brings a claim against Mozilla related to Your use of AMO or Your Add-ons, You will defend and hold Mozilla harmless from and against all damages, losses, and expenses of any kind (including reasonable legal fees and costs) related to such claim.
+If any third party brings a claim against MZLA related to Your use of ATN or Your Add-ons, You will defend and hold MZLA harmless from and against all damages, losses, and expenses of any kind \(including reasonable legal fees and costs\) related to such claim.
 
 ## 11. General legal terms
 
-(a) Governing Law & Language. THESE TERMS, AND YOUR RELATIONSHIP WITH MOZILLA UNDER THESE TERMS, SHALL BE GOVERNED BY THE LAWS OF THE STATE OF CALIFORNIA IN THE UNITED STATES OF AMERICA WITHOUT REGARD TO ITS CONFLICT OF LAWS PROVISIONS. You and Mozilla agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, in the state of California to resolve any legal matter arising from these Terms. Notwithstanding this, You agree that Mozilla shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction. In the event of conflicts between a translated version of this Agreement and the English language version, the English language version shall control.
+#### \(a\) Governing Law & Language.
 
-(b) Severability; No Waiver. If any court of law, having the jurisdiction to decide on this matter, rules that any provision of this Agreement are invalid, then that provision will be removed from this Agreement without affecting the rest of the Agreement. The remaining provisions of this Agreement will continue to be valid and enforceable. You agree that if Mozilla does not exercise or enforce any legal right or remedy which is contained in this Agreement (or which Mozilla has the benefit of under any applicable law), this will not be taken to be a formal waiver of Mozilla's rights and that those rights or remedies will still be available to Mozilla.
+THESE TERMS, AND YOUR RELATIONSHIP WITH MZLA UNDER THESE TERMS, SHALL BE GOVERNED BY THE LAWS OF THE STATE OF CALIFORNIA IN THE UNITED STATES OF AMERICA WITHOUT REGARD TO ITS CONFLICT OF LAWS PROVISIONS.
 
-Entire Agreement. This Agreement constitutes the whole legal agreement between You and Mozilla for distribution of Add-ons, and completely supersedes any other related agreements between You and Mozilla unless You have a separately negotiated and signed agreement in connection with a specific Add-on ("Custom Agreement"), in which case the Custom Agreement controls. Hyperlinked documents in this Agreement, including for example, Review Policies, are incorporated herein by reference.
+You and MZLA agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, in the state of California to resolve any legal matter arising from these Terms. Notwithstanding this, You agree that MZLA shall still be allowed to apply for injunctive remedies \(or an equivalent type of urgent legal relief\) in any jurisdiction. In the event of conflicts between a translated version of this Agreement and the English language version, the English language version shall control.
 
-(c) Termination. To terminate this Agreement You must provide Mozilla with 30 days prior written notice of such termination. Sections 8-11 of this Agreement shall survive termination.
+#### \(b\) Severability; No Waiver. 
 
-(d) Assignment. The rights granted in this Agreement may not be assigned or transferred by You without the prior written approval of Mozilla. You are not permitted to delegate Your responsibilities or obligations under this Agreement without the prior written approval of Mozilla.
+If any court of law, having the jurisdiction to decide on this matter, rules that any provision of this Agreement are invalid, then that provision will be removed from this Agreement without affecting the rest of the Agreement. The remaining provisions of this Agreement will continue to be valid and enforceable. You agree that if MZLA does not exercise or enforce any legal right or remedy which is contained in this Agreement \(or which MZLA has the benefit of under any applicable law\), this will not be taken to be a formal waiver of MZLA's rights and that those rights or remedies will still be available to MZLA.
 
-(e) Modification. Mozilla may periodically update this Agreement. The updated Agreement will be available online. If the changes are substantive, we will announce the update through Mozilla’s usual channels for such announcements such as blog posts, forums, or email. Your continued distribution of Your Add-on after the effective date of such changes constitutes Your acceptance of such changes. To make Your review more convenient, we will post an effective date on the Agreement.
+Entire Agreement. This Agreement constitutes the whole legal agreement between You and MZLA for distribution of Add-ons, and completely supersedes any other related agreements between You and MZLA unless You have a separately negotiated and signed agreement in connection with a specific Add-on \("Custom Agreement"\), in which case the Custom Agreement controls. Hyperlinked documents in this Agreement, including for example, [Review Policies](review-policy-for-thunderbird-add-ons.md), are incorporated herein by reference.
 
-(f) Contact Us. If You have questions about this Agreement, send an email to legal-notices@mozilla.com or mail us at: Attn: Mozilla – Legal Notices, 331 E. Evelyn Ave., Mountain View, CA 94041.
+#### \(c\) Termination
+
+To terminate this Agreement You must provide MZLA with 30 days prior written notice of such termination. Sections 8-11 of this Agreement shall survive termination.
+
+#### \(d\) Assignment
+
+The rights granted in this Agreement may not be assigned or transferred by You without the prior written approval of MZLA. You are not permitted to delegate Your responsibilities or obligations under this Agreement without the prior written approval of MZLA.
+
+#### \(e\) Modification
+
+MZLA may periodically update this Agreement. The updated Agreement will be available online. If the changes are substantive, we will announce the update through MZLA’s usual channels for such announcements such as blog posts, forums, or email. Your continued distribution of Your Add-on after the effective date of such changes constitutes Your acceptance of such changes. To make Your review more convenient, we will post an effective date on the Agreement.
+
+#### \(f\) Contact Us
+
+If You have questions about this Agreement, send an email to {**todo**: **check and update for MZLA**: legal-notices@mozilla.com or mail us at: Attn: Mozilla – Legal Notices, 331 E. Evelyn Ave., Mountain View, CA 94041.}
 

--- a/add-ons/add-on-policies/thunderbird-add-on-distribution-agreement.md
+++ b/add-ons/add-on-policies/thunderbird-add-on-distribution-agreement.md
@@ -10,16 +10,16 @@ MZLA is committed to promoting choice and innovation on the web. From the launch
 
 This Thunderbird Add-on Distribution Agreement \("Agreement"\) governs Your distribution of Thunderbird Add-ons. Frequently used terms in this Agreement are defined below.
 
-* “Add-on” means software that extends the functionality of Thunderbird, for example, extensions, Background Themes \(defined below\), search providers, dictionaries, and language packs. Add-ons are also commonly referred to as extensions or plugins.
+* “Add-on” means software that extends the functionality of Thunderbird, for example, extensions, themes \(defined below\), search providers, dictionaries, and language packs. Add-ons are also commonly referred to as extensions or plugins.
 * “Add-on Manager” is the Thunderbird tool to manage Add-ons. It can be accessed from the Thunderbird menu button in the toolbar.
 * “ATN” means addons.thunderbird.net, which is our online platform for developers to list and distribute Add-ons to End-Users.
-* “Background Theme” means software that personalizes the look of Thunderbird by adding a background design to the main toolbar. Themes are a type of Add-on.
+* “theme” means software that personalizes the look of Thunderbird. Themes are a type of Add-on.
 * “Brand Features” mean the trade names, trademarks, service marks, logos, domain names, and other distinctive brand features of You, Mozilla or MZLA.
 * “End-Users” mean individuals who install Add-Ons, or to whom Add-ons are promoted.
 * “Thunderbird” means the awesome email client developed by the Thunderbird community.
 * “Listed Add-on” means Add-ons that are listed and distributed on ATN.
 * “Mozilla” means Mozilla Corporation and its affiliated entities.
-* “MZLA” means {... } and designated community members who are part of the Add-on review process.
+* “MZLA” means [todo] and designated community members who are part of the Add-on review process.
 * “Unlisted Add-on” means Add-ons that are distributed to End-Users via means other than ATN.
 * “You” means the person or entity entering this Agreement for the purpose of distributing a Thunderbird Add-on.
 


### PR DESCRIPTION
This work is based on the firefox distribution agreement taken from here:
https://extensionworkshop.com/documentation/publish/firefox-add-on-distribution-agreement/

This first step is updating links where possible and replaces Mozilla by MZLA which I picked as a placeholder. Ryan used "Thunderbird Team" in the other document, which might fit as well. But someone with more legal insight needs to decide what is correct.

I also added some todos were more work is needed.

Approving this PR will not make it visible on DTN, as it will be merged into the "add-add-on-policies" branch. Once we have everything up and running, we can merge that into master to add them to DTN.