### PR TITLE
Add page of useful dev links for both C++ and js.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -24,6 +24,8 @@
   * [Running Tests](thunderbird-development/testing/running-tests.md)
   * [Adding Tests](thunderbird-development/testing/adding-tests.md)
   * [Writing Mochitest Tests](thunderbird-development/testing/writing-mochitest-tests.md)
+* [C++ Development](thunderbird-development/c++-reference.md)
+* [Javascript Development](thunderbird-development/javascript-reference.md)
 
 ## Planning
 

--- a/thunderbird-development/c++-reference.md
+++ b/thunderbird-development/c++-reference.md
@@ -1,0 +1,47 @@
+---
+description: Useful links for working on Thunderbird in C++.
+---
+# C++ References and resources
+
+## Coding style
+
+- The [Firefox C++ style guide](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html) is used for Thunderbird.
+- Use [clang-format](https://firefox-source-docs.mozilla.org/code-quality/coding-style/format_cpp_code_with_clang-format.html) to check (and tweak) your formatting.
+
+## Strings
+
+- See the [string](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html#strings) section of the Mozilla C++ code style.
+- The [Mozilla Internal string guide](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Internal_strings) (archived) still the most in-depth guide to the available classes and their use.
+
+## Arrays
+
+- [XPCOM array guide](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Arrays) (archived and _mostly_ valid. But beware.)
+- NOTE: don't use `nsIArray`/`nsIMutableArray` in new code. `nsTArray` is much more ergonomic for both C++ and Javascript.
+
+## XPCOM
+
+- [Mozilla XPCOM docs](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM) (archived)
+- [RefPtr](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Glue_classes/nsRefPtr) (including how it differs from nsCOMPtr).
+- [IDL style guide](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html#idl)
+- [XPIDL](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPIDL)
+
+## File handling
+
+- [nsIFile](https://searchfox.org/mozilla-central/source/xpcom/io/nsIFile.idl) provides platform-independent path manipulation.
+
+## Dealing with memory leaks
+
+- [ASan](https://firefox-source-docs.mozilla.org/tools/sanitizer/asan.html#address-sanitizer) (Address Sanitizer)
+- [Leak-hunting strategies](https://developer.mozilla.org/en-US/docs/Mozilla/Performance/Leak-hunting_strategies_and_tips) (archived, out of date, but still some useful information)
+- [DMD](https://developer.mozilla.org/en-US/docs/Mozilla/Performance/DMD) "Dark Matter Detector. (Archived.)
+- [Valgrind](https://web.archive.org/web/20180309013311/https://developer.mozilla.org/en-US/docs/Mozilla/Testing/Valgrind) (On archive.org. Would be nice to update this info).
+
+## Netscape Portable Runtime (NSPR)
+
+- Provides platform-independent low level functionality (threads, timers, I/O etc).
+- [NSPR Docs](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR) (archived)
+
+## LDAP
+
+- [Mozilla LDAP SDK](https://wiki.mozilla.org/Mozilla_LDAP_SDK_Programmer%27s_Guide/LDAP_C_SDK_Function_Reference) (ancient, but mostly correct).
+

--- a/thunderbird-development/javascript-reference.md
+++ b/thunderbird-development/javascript-reference.md
@@ -1,0 +1,20 @@
+---
+description: Useful links for working on Thunderbird in Javascript.
+---
+# Javascript References and resources
+
+## Coding style
+
+- [Mozilla Javascript coding style](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_js.html)
+
+## File handling
+
+- [IOUtils](https://searchfox.org/mozilla-central/source/dom/chrome-webidl/IOUtils.webidl) for file IO
+- [PathUtils](https://searchfox.org/mozilla-central/source/dom/chrome-webidl/PathUtils.webidl) for path manipulation
+
+## IDL files
+
+- [IDL style guide](https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html#idl)
+- [XPIDL](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPIDL)
+
+


### PR DESCRIPTION
The beginnings of some long-overdue C++ development docs (and JS docs to mirror them, although that's less my area of expertise).

My idea is that C++ and JS both have a single dense page each that references a whole bunch of useful documentation (and gives some clue as to how up-to-date those links are!). That's what this PR is.

(I've got lots of plans and notes for fleshing it all out into something really useful, but there's a lot to wrangle. I need to pick off some smaller areas to refine down for public comsumption. Ultimately I want a guide for both experienced TB hackers and people coming in for the first time).
