### PR TITLE
Updating links in `Make Your Build Faster` with replacements #119

### DIFF
--- a/thunderbird-development/building-thunderbird/README.md
+++ b/thunderbird-development/building-thunderbird/README.md
@@ -54,7 +54,7 @@ Building can take a significant amount of time, depending on your system, OS, an
 
 ### Make Your Build Faster
 
-Follow this guide to rely on `ccache` and other [Tips for making builds faster](../getting-started.md).
+Follow this guide to rely on [sccache](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/ccache) and other [Tips for making builds faster](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Mozilla_build_FAQ#making_builds_faster).
 
 ## Running Thunderbird
 


### PR DESCRIPTION
Updating links in `Make Your Build Faster` with replacements mentioned in #119 by Liscare.

Both are archived although the `sccache` hint seems to be up to date.