### PR TITLE
Replace backslash with forward slash

### DIFF
--- a/thunderbird-development/building-thunderbird/README.md
+++ b/thunderbird-development/building-thunderbird/README.md
@@ -19,7 +19,7 @@ Depending on your Operating System you will need to carry out a different proces
 
 ## Build Configuration
 
-To build Thunderbird, you need to create a file named `mozconfig` to the root directory of the mozilla-central checkout that contains the option `comm\mail` enabled. You can create a file with this line by doing this in the `source/` directory:
+To build Thunderbird, you need to create a file named `mozconfig` to the root directory of the mozilla-central checkout that contains the option `comm/mail` enabled. You can create a file with this line by doing this in the `source/` directory:
 
 ```text
 echo 'ac_add_options --enable-application=comm/mail' > mozconfig


### PR DESCRIPTION
This particular section of this document tends to *assume* that the individual trying to or building Thunderbird is running on a Windows system.

The change here makes the document consistent.