### PR TITLE
Update developer mailing list link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-description: >-
+Description: >-
   Thunderbird is a powerful and customizable open source Email client with
   millions of users. It is based on the Mozilla platform that Firefox is also
   built on. These docs teach you how to contribute!
@@ -43,10 +43,10 @@ We have a complete listing of the ways in which you can get involved with Thunde
 
 ### Mailing Lists
 
-If you want to participate in discussions about Thunderbird development, there are two main mailing lists you want to join.
+If you want to participate in discussions about Thunderbird development, these are the main channels.
 
 1. [**TB-Planning**](https://wiki.mozilla.org/Thunderbird/tb-planning)**:** This mailing list is higher level topics like: the future of Thunderbird, potential features, and changes that you would like to see happen. It is also used to discuss a variety of broader issues around community and governance of the project.
-2. [**Maildev**](http://lists.thunderbird.net/mailman/listinfo/maildev_lists.thunderbird.net)**:** A moderated mailing list for discussing engineering plans for Thunderbird. It is a place where you can raise questions and ideas for core Thunderbird development.
+2. [**Topicbox**](https://thunderbird.topicbox.com/groups/developers)**:** A moderated mailing list for discussing engineering plans for Thunderbird. It is a place where you can raise questions and ideas for core Thunderbird development.
 3. [**Add-on Developers**](https://thunderbird.topicbox.com/groups/addons): A list for Thunderbird add-on developers and aspiring add-on developers to ask questions and share knowledge.
 
 ### Chat


### PR DESCRIPTION
The developer mailing list link pointing to https://lists.thunderbird.net/mailman/listinfo/maildev_lists.thunderbird.net now 404s. After discussion in TB dev chat (https://chat.mozilla.org/#/room/#maildev:mozilla.org) it was suggested the topicbox link is the new location. Also updated the text above so it makes sense. Previously it said "these two mail mailing lists" so I've changed it to "these are the main channels" to make it more generic.