### PR TITLE
move the build prequisites in a designated space

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,10 +5,11 @@
 ## Contributing to Thunderbird <a href="thunderbird-development" id="thunderbird-development"></a>
 
 * [Getting Started](thunderbird-development/getting-started.md)
+* [Prerequisites for the build](thunderbird-development/prerequisites-build/README.md)
+  * [Windows Build Prerequisites](thunderbird-development/prerequisites-build/windows-build-prerequisites.md)
+  * [Linux Build Prerequisites](thunderbird-development/prerequisites-build/linux-build-prerequisites.md)
+  * [macOS Build Prerequisites](thunderbird-development/prerequisites-build/macos-build-prerequisites.md)
 * [Building Thunderbird](thunderbird-development/building-thunderbird/README.md)
-  * [Windows Build Prerequisites](thunderbird-development/building-thunderbird/windows-build-prerequisites.md)
-  * [Linux Build Prerequisites](thunderbird-development/building-thunderbird/linux-build-prerequisites.md)
-  * [macOS Build Prerequisites](thunderbird-development/building-thunderbird/macos-build-prerequisites.md)
   * [Artifact Builds](thunderbird-development/building-thunderbird/artifact-builds.md)
 * [Codebase Overview](thunderbird-development/codebase-overview/README.md)
   * [Chat Core](thunderbird-development/codebase-overview/chat/README.md)

--- a/thunderbird-development/building-thunderbird/README.md
+++ b/thunderbird-development/building-thunderbird/README.md
@@ -4,37 +4,15 @@ description: How to build and run Thunderbird.
 
 # Building Thunderbird
 
-## Hardware Requirements
+## Prerequisites
 
-* At least **4 GB of RAM**. 8 GB or more is recommended. While you can build Thunderbird on older hardware it can take quite a bit of time to compile on slower machines with less RAM.
-* Good internet connection for the initial source download.
+Ensure that your [Prerequisites for the build](thunderbird-development/prerequisites-build/README.md) are met.
 
-## Build Prerequisites
+You should have done the following:
 
-Depending on your Operating System you will need to carry out a different process to prepare your machine. So firstly complete the instructions for your OS and then continue following these build instructions.
-
-* [Windows Build Prerequisites](windows-build-prerequisites.md)
-* [Linux Build Prerequisites](linux-build-prerequisites.md)
-* [macOS Build Prerequisites](macos-build-prerequisites.md)
-
-## Build Configuration
-
-To build Thunderbird, you need to create a file named `mozconfig` to the root directory of the mozilla-central checkout that contains the option `comm/mail` enabled. You can create a file with this line by doing this in the `source/` directory:
-
-```text
-echo 'ac_add_options --enable-application=comm/mail' > mozconfig
-echo 'ac_add_options --with-app-basename=Thunderbird' >> mozconfig
-```
-
-**If you omit these lines, the build system will build Firefox instead**. Other build configuration options can be added to this file, although it's **strongly recommended** that you only use options that you fully understand. For example, to create a debug build instead of a release build, that file would also contain the line:
-
-```text
-echo 'ac_add_options --enable-debug' >> mozconfig
-```
-
-_Each of these ac\_add\_options entries needs to be on its own line._
-
-For more on configuration options, see the page [Configuring build options](https://developer.mozilla.org/en/Configuring_Build_Options). Note that if you use an MOZ\_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!
+* installed tools for ./mach bootstrap depending on your OS
+* finished ./mach bootstrap in `Firefox for Desktop` mode
+* The [Build Configuration](thunderbird-development/prerequisites-build/README.md) in a seperate `source/mozconfig` file so that Thunderbird is build and not Firefox
 
 ## Building
 
@@ -42,7 +20,7 @@ For more on configuration options, see the page [Configuring build options](http
 Before you start, make sure that the version you checked out is not busted. For `hg` tip, you should see green Bs on [https://treeherder.mozilla.org/\#/jobs?repo=comm-central](https://treeherder.mozilla.org/#/jobs?repo=comm-central)
 {% endhint %}
 
-After you met the [build prerequisites](./#build-prerequisites) for your OS the build is started in the `source` directory with:
+The build is started in the `source` directory with:
 
 ```text
 ./mach build

--- a/thunderbird-development/getting-started.md
+++ b/thunderbird-development/getting-started.md
@@ -21,15 +21,15 @@ Information for how to install Mercurial is available [via the download page on 
 ## Get the Source
 
 {% hint style="warning" %}
-The source code requires 3.6GB of free space or more and additionally 5GB or more for default build.
+The source code requires 3.6GB of free space or more and additionally 30GB or more for default build.
 {% endhint %}
 
 {% hint style="danger" %}
 **For Windows Users: **If you are using Windows, you will want to follow instructions on the Windows Build Prerequisities page before getting the source and building Thunderbird.
 {% endhint %}
 
-{% content-ref url="building-thunderbird/windows-build-prerequisites.md" %}
-[windows-build-prerequisites.md](building-thunderbird/windows-build-prerequisites.md)
+{% content-ref url="prerequisites-build/windows-build-prerequisites.md" %}
+[windows-build-prerequisites.md](prerequisites-build/windows-build-prerequisites.md)
 {% endcontent-ref %}
 
 Get the latest Mozilla source code from Mozilla's `mozilla-central` Mercurial code repository, and check it out into a local directory `source` (or however you want to call it). Then, get the latest Thunderbird source code from Mozilla's `comm-central` Mercurial code repository. It now needs to be placed **inside** the Mozilla source code, in a directory named `comm/`:

--- a/thunderbird-development/prerequisites-build/README.md
+++ b/thunderbird-development/prerequisites-build/README.md
@@ -1,0 +1,47 @@
+---
+description: Prepare build of Thunderbird.
+---
+
+# Prerequisites for the build
+
+## Hardware Requirements
+
+* At least **4 GB of RAM**. 8 GB or more is recommended. While you can build Thunderbird on older hardware it can take quite a bit of time to compile on slower machines with less RAM.
+* Good internet connection for the initial source download.
+
+## 30 GB of free space
+
+The Thunderbird build will take up to 30 GB of disk space in order to complete. Be sure to have enough free space and a fast internet connection to avoid interruptions.
+
+## Build Prerequisites
+
+Depending on your Operating System you will need to carry out a different process to prepare your machine. So firstly complete the instructions for your OS and then continue following the setup with the [Build Configuration](./#build-configuration).
+
+* [Windows Build Prerequisites](windows-build-prerequisites.md)
+* [Linux Build Prerequisites](linux-build-prerequisites.md)
+* [macOS Build Prerequisites](macos-build-prerequisites.md)
+
+## Build Configuration
+
+To build Thunderbird, you need to create a file named `mozconfig` to the root directory of the mozilla-central checkout that contains the option `comm/mail` enabled. You can create a file with this line by doing this in the `source/` directory:
+
+```text
+echo 'ac_add_options --enable-application=comm/mail' > mozconfig
+echo 'ac_add_options --with-app-basename=Thunderbird' >> mozconfig
+```
+
+**If you omit these lines, the build system will build Firefox instead**. Other build configuration options can be added to this file, although it's **strongly recommended** that you only use options that you fully understand. For example, to create a debug build instead of a release build, that file would also contain the line:
+
+```text
+echo 'ac_add_options --enable-debug' >> mozconfig
+```
+
+_Each of these ac\_add\_options entries needs to be on its own line._
+
+For more on configuration options, see the page [Configuring build options](https://developer.mozilla.org/en/Configuring_Build_Options). Note that if you use an MOZ\_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!
+
+## You're all set
+
+Go ahead to the [Building Thunderbird](thunderbird-development/building-thunderbird/README.md) page and continue following the guide.
+
+{% page-ref page="./" %}

--- a/thunderbird-development/prerequisites-build/linux-build-prerequisites.md
+++ b/thunderbird-development/prerequisites-build/linux-build-prerequisites.md
@@ -24,10 +24,6 @@ You’ll need `Python 3.6` installed.
 
 You can check with `python --version` to see if you have it already. If not, you can install it with your distribution’s package manager. Make sure your system is up to date!
 
-## 30 GB of free space
-
-The Thunderbird build will take up to 30 GB of disk space in order to complete. Be sure to have enough free space and a fast internet connection to avoid interruptions.
-
 ## Bootstrap your system
 
 Access the location where you downloaded the `mozilla-central` source code, most likely `source/` and trigger this command:
@@ -76,7 +72,7 @@ If you still are unable to find rustc and cargo via the ˋwhichˋ command after 
 
 ## You're all set
 
-Got back to the [Building Thunderbird](./#build-configuration) page and continue following the guide.
+Go back to the [Prerequisites for the build](./#build-configuration) page and continue following the guide.
 
 {% page-ref page="./" %}
 

--- a/thunderbird-development/prerequisites-build/macos-build-prerequisites.md
+++ b/thunderbird-development/prerequisites-build/macos-build-prerequisites.md
@@ -70,7 +70,7 @@ export PATH=$HOME/.cargo/bin:$PATH
 
 ## You're all set
 
-Got back to the [Building Thunderbird](./#build-configuration) page and continue following the guide:
+Got back to the [Prerequisites for the build](./#build-configuration) page and continue following the guide:
 
 {% page-ref page="./" %}
 

--- a/thunderbird-development/prerequisites-build/windows-build-prerequisites.md
+++ b/thunderbird-development/prerequisites-build/windows-build-prerequisites.md
@@ -73,13 +73,8 @@ This action will install all the remaining libraries and dependencies necessary 
 **Make sure to restart after installing all the requirements, or Thunderbird might encounter a build error.**
 {% endhint %}
 
-### Building Thunderbird
+## You're all set
 
-Now that you have the prerequisites for Windows, make sure you have the source code via the commands on the Getting Started page:
-
-{% page-ref page="../getting-started.md" %}
-
-Then you can follow the instructions on the Building Thunderbird page:
+Go back to the [Prerequisites for the build](./#build-configuration) page and continue following the guide:
 
 {% page-ref page="./" %}
-


### PR DESCRIPTION
Hey,

its a more of a bigger overhaul.
I've been through the process of setting up a Thunderbird repository twice and every stumbled upon the prerequisites.

My reasoning behind the change:

* macOS, linux and windows leaves the space of a "wizard" style, clicking next
* giving a short summary in the build what you should have done before
* it's the most broad topic for building and deserves to be an extra point to reduce confusion