### PR TITLE
Remove mention of ldap folder from codebase-overview page

### DIFF
--- a/thunderbird-development/codebase-overview/README.md
+++ b/thunderbird-development/codebase-overview/README.md
@@ -28,9 +28,6 @@ The subdirectories are:
 * **protocols** Various protocol implementations. Each of subdirectory implements a protocol to the interfaces found under **components**.
 * **themes** Common and platform-specific styling specific to chat. Files from this directory become `chrome://chat/skin/…`.
 
-**ldap**  
-The LDAP C SDK. Used for communicating with LDAP servers.
-
 **mail**  
 Thunderbird specific source code. It's no coincidence that this folder is laid out a lot like the `browser` and `toolkit` directories on mozilla-central. Many of the subdirectories follow the same pattern:
 


### PR DESCRIPTION
ldap c-sdk was removed in bug 1729862