### PR TITLE
Expand documentation on add-on ids

### DIFF
--- a/add-ons/mailextensions/README.md
+++ b/add-ons/mailextensions/README.md
@@ -81,7 +81,11 @@ The `name` and the `description` of the given example are only in English. [This
 
 The `applications.gecko` manifest key defines the following properties:
 
-* `id` : The id serves as a unique identifier for the extension, common practice is to use `add-on-name@your-website`. Providing an id is mandatory in order upload an extension to ATN or to be able to install it from an XPI file.
+* `id`: The id serves as a unique identifier for the extension and is mandatory in order upload an extension to ATN or to be able to install it from an XPI file.
+
+  Best practice is to use "email-address-style" ids on a domain you control, for example `name-of-your-addon@example.com`, if you own `example.com`.  As the id of your add-on cannot get changed once it is published, it is highly recommended to use a domain that you plan to keep for the forseeable future. If you don't have a domain that fits the bill, feel free to use `your-atn-username.addons.thunderbird.net` (based on your username on [ATN](https://addons.thunderbird.net/)).
+
+  Alternatively to the preferred style, you may use an UUID enclosed in curly braces, for example `{e4aa2097-8ee9-49a4-9ec7-c633b1e8dfda}`. Make sure you generate a new UUID for each add-on you want to develop, you can find free UUID generators throughout the internet.
 * `strict_min_version`: Defines the lowest targeted version of Thunderbird.
 * `strict_max_version`:  Defines the highest targeted version of Thunderbird. It can be set to a specific version or a broader match to limit it to a branch (for example `78.*`).&#x20;
 


### PR DESCRIPTION
This commit adds documentation on the necessity of stable domains for
email-style add-on-ids, as well as two alternatives for users that do not
own a domain (constructing one based on the ATN username or using UUIDs).