### PR TITLE
Command "mach try empty" needs parameter --push-to-vcs

### DIFF
--- a/thunderbird-development/fixing-a-bug/try-server.md
+++ b/thunderbird-development/fixing-a-bug/try-server.md
@@ -148,9 +148,9 @@ When the build at `https://treeherder.mozilla.org/jobs?repo=try-comm-central` is
 
 If you have changes that affect mozilla-central, you may wish to do a Try run to check Thunderbird isn't broken. Here's how:
 
-1. In your mozilla-central directory, apply your patch. Then run `./mach try empty` to push to the mozilla-central Try repository. You'll need to know the revision number of your push, which will be in the message printed to the console.
+1. In your mozilla-central directory, apply your patch. Then run `./mach try empty --push-to-vcs` to push to the mozilla-central Try repository. You'll need to know the revision number of your push, which will be in the message printed to the console.
 2. Move to your comm-central directory.
-3. Modify the file `.gecko_rev.yml` – change `GECKO_HEAD_REPOSITORY` to [`https://hg.mozilla.org/try`](https://hg.mozilla.org/try), and `GECKO_HEAD_REV` to point to the revision you previously pushed to M-C's try with `mach try empty`.
+3. Modify the file `.gecko_rev.yml` – change `GECKO_HEAD_REPOSITORY` to [`https://hg.mozilla.org/try`](https://hg.mozilla.org/try), and `GECKO_HEAD_REV` to point to the revision from step 1.
 4. Now push to try-comm-central as per usual.
 
 You can change `.gecko_rev.yml` to point to any revision on the mozilla-\* trees to test your comm-central patch against them.


### PR DESCRIPTION
The plain command no longer works, document the parameter that's now required.
